### PR TITLE
Missing dependency in Franco test

### DIFF
--- a/franco/package.json
+++ b/franco/package.json
@@ -8,6 +8,7 @@
   },
   "author": "",
   "dependencies": {
+    "dotenv": "8.2.0",
     "psaas-js-api": "bitbucket:psaasredapp/psaas-js-api"
   },
   "license": "ISC"


### PR DESCRIPTION
Franco's test has a dependency on dotenv to load environment variables.
Add it to the package.json.