### PR TITLE
Fixes for test_remote.js

### DIFF
--- a/test_remote.js
+++ b/test_remote.js
@@ -42,7 +42,7 @@ modeller.client.JobManager.setDefaults({
   host: serverConfig.mqttAddress,
   port: serverConfig.mqttPort,
   topic: serverConfig.mqttTopic,
-  username: serverConfig.mqttUsername,
+  username: serverConfig.mqttUser,
   password: serverConfig.mqttPassword,
 });
 //the directory of the test files

--- a/test_remote.js
+++ b/test_remote.js
@@ -155,7 +155,7 @@ function handleErrorNode(node) {
 
   let projAttachment = prom.addAttachment("elevation.prj", projContents);
   let elevAttachment = prom.addAttachment("elevation.asc", elevContents);
-  let fuelMapAttachment = prom.addAttachment("elevation.prj", fuelmapContents);
+  let fuelMapAttachment = prom.addAttachment("fbp_fuel_type.asc", fuelmapContents);
   let lutFileAttachment = prom.addAttachment("fbp_lookup_table.csv", lutFileContents);
   let curingGridAttachment = prom.addAttachment("degree_of_curing.asc", curingGridContents);
   let curingProjAttachment = prom.addAttachment("degree_of_curing.prj", curingPrjContents);


### PR DESCRIPTION
Two fixes for test_remote.js.
- The second one is a filename fix for the fuelmap that stopped the fuelmap from existing when PSaas attempted to run the generated FGMJ. This was being returned as an error when PSaaS validation was called but that message was never received by the client script because of the other issue.
- The name of the property used to store the MQTT username was `mqttUser` in `serverConfigOverride` but it was used as `mqttUsername` when the defaults were being set in the job manager. So if the broker required authentication it was hanging the request without it. This type of issue could be detected easier with TypeScript over JavaScript. See a comparison in VSCode (JavaScript left, TypeScript right with the only change being the file extension).
![jsvsts](https://user-images.githubusercontent.com/1920516/103470200-f5a80700-4d34-11eb-84b1-01ffd79ed568.png)
